### PR TITLE
feat(categories): add soft delete and restore functionality

### DIFF
--- a/src/migrations/1746122457196-AddDeletedAtColumnInCategoryTable.ts
+++ b/src/migrations/1746122457196-AddDeletedAtColumnInCategoryTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddDeletedAtColumnInCategoryTable1746122457196 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Adicionar coluna deletedAt à tabela category
+        await queryRunner.addColumn('category', new TableColumn({
+            name: 'deleted_at',
+            type: 'timestamp',
+            isNullable: true,
+            default: null,
+        }))
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Remover coluna deletedAt da tabela category
+        await queryRunner.dropColumn('category', 'deleted_at');
+    }
+
+}

--- a/src/products/categories/categories.controller.ts
+++ b/src/products/categories/categories.controller.ts
@@ -18,7 +18,7 @@ import { DeleteResult } from 'typeorm';
 @Controller('categories')
 @ApiTags('Categories')
 export class CategoriesController {
-  constructor(private readonly categoriesService: CategoriesService) {}
+  constructor(private readonly categoriesService: CategoriesService) { }
 
   @Post()
   async create(
@@ -54,7 +54,16 @@ export class CategoriesController {
   }
 
   @Delete(':id')
-  async remove(@Param('id', ParseIntPipe) id: number): Promise<DeleteResult> {
-    return await this.categoriesService.remove(id);
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<ReturnCategoryDto> {
+    return new ReturnCategoryDto(
+      await this.categoriesService.remove(id),
+    );
+  }
+
+  @Post(':id/restore')
+  async restore(@Param('id', ParseIntPipe) id: number): Promise<ReturnCategoryDto> {
+    return new ReturnCategoryDto(
+      await this.categoriesService.restore(id),
+    );
   }
 }

--- a/src/products/categories/categories.service.ts
+++ b/src/products/categories/categories.service.ts
@@ -19,7 +19,7 @@ export class CategoriesService {
     private readonly repository: Repository<Category>,
     @Inject(forwardRef(() => ProductsService))
     private readonly productsService: ProductsService,
-  ) {}
+  ) { }
 
   async create(createCategoryDto: CreateCategoryDto): Promise<Category> {
     const category = await this.findOneByName(createCategoryDto.name).catch(
@@ -74,8 +74,10 @@ export class CategoriesService {
     });
   }
 
-  async remove(id: number): Promise<DeleteResult> {
+  async remove(id: number): Promise<Category> {
     const category = await this.findOne(id, true);
+
+    console.log(category);
 
     if (category.products?.length > 0) {
       throw new BadRequestException(
@@ -83,6 +85,12 @@ export class CategoriesService {
       );
     }
 
-    return await this.repository.delete(id);
+    return await this.repository.softRemove(category);
+  }
+
+  async restore(id: number): Promise<Category> {
+    await this.repository.restore(id);
+
+    return await this.findOne(id);
   }
 }

--- a/src/products/categories/entities/category.entity.ts
+++ b/src/products/categories/entities/category.entity.ts
@@ -2,6 +2,7 @@ import { Product } from '../../entities/product.entity';
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -21,6 +22,9 @@ export class Category {
 
   @UpdateDateColumn({ name: 'updated_at', nullable: false })
   updatedAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date;
 
   @OneToMany(() => Product, (product: Product) => product.category)
   products?: Product[];

--- a/src/products/categories/tests/mocks/category.mock.ts
+++ b/src/products/categories/tests/mocks/category.mock.ts
@@ -5,4 +5,5 @@ export const categoryMock: Category = {
   name: 'Category Mock',
   createdAt: new Date(),
   updatedAt: new Date(),
+  deletedAt: null,
 };


### PR DESCRIPTION
Introduce soft delete and restore capabilities for categories. This includes adding a `deletedAt` column to the `category` table, updating the service to use soft delete and restore methods, and modifying the controller to handle these operations. This change allows for more flexible category management by enabling recovery of deleted categories.